### PR TITLE
Add the ability to include a note when adding a task

### DIFF
--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -33,6 +33,7 @@ app
   .option('--today', 'Set the due date to today')
   .option('--tomorrow', 'Set the due date to tomorrow')
   .option('--due [date]', 'Set a specific due date')
+  .option('--note [note]', 'Attach a note to the new task')
   .option('-o, --open', 'Open Wunderlist on completion')
   .option('-s, --stdin', 'Create tasks from stdin')
   .parse(process.argv)
@@ -110,6 +111,22 @@ function main () {
             console.error(JSON.stringify(err || body.error, null, 2))
             process.exit(1)
           }
+
+          cb(null, body)
+        })
+      },
+      function (task, cb) {
+        note = {
+          task_id: task.id,
+          content: app.note
+        }
+
+        api.post({url: '/notes', body: note}, function (err, res, body) {
+          if (err || body.error) {
+            console.error(JSON.stringify(err || body.error, null, 2))
+            process.exit(1)
+          }
+
           cb(null, body)
         })
       }

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -116,19 +116,23 @@ function main () {
         })
       },
       function (task, cb) {
-        note = {
-          task_id: task.id,
-          content: app.note
-        }
-
-        api.post({url: '/notes', body: note}, function (err, res, body) {
-          if (err || body.error) {
-            console.error(JSON.stringify(err || body.error, null, 2))
-            process.exit(1)
+        if (app.note) {
+          note = {
+            task_id: task.id,
+            content: app.note
           }
 
+          api.post({url: '/notes', body: note}, function (err, res, body) {
+            if (err || body.error) {
+              console.error(JSON.stringify(err || body.error, null, 2))
+              process.exit(1)
+            }
+
+            cb(null, task)
+          })
+        } else {
           cb(null, task)
-        })
+        }
       }
     ], function (err, res) {
       if (err) {

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -127,7 +127,7 @@ function main () {
             process.exit(1)
           }
 
-          cb(null, body)
+          cb(null, task)
         })
       }
     ], function (err, res) {

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -117,12 +117,7 @@ function main () {
       },
       function (task, cb) {
         if (app.note) {
-          note = {
-            task_id: task.id,
-            content: app.note
-          }
-
-          api.post({url: '/notes', body: note}, function (err, res, body) {
+          api.post({url: '/notes', body: { task_id: task.id, content: app.note }}, function (err, res, body) {
             if (err || body.error) {
               console.error(JSON.stringify(err || body.error, null, 2))
               process.exit(1)


### PR DESCRIPTION
This is a pretty simple PR that adds a --note argument that you can use to include a note with a newly created task.

Example:
`$ wunderline add --note 'some helpful notes' my new task`
