### PR TITLE
Implemented dynamic tty column width resolution

### DIFF
--- a/lib/print-list.js
+++ b/lib/print-list.js
@@ -5,13 +5,19 @@ var moment = require('moment')
 var skipEmpty = true
 
 function printTasks (tasks) {
+  var ttyMaxWidth = 60;
+
+  if (process.stdout.isTTY) {
+    ttyMaxWidth = process.stdout.columns;
+  }
+
   var options = {
     showHeaders: false,
     truncate: true,
     config: {
       title: {
         minWidth: 60,
-        maxWidth: 60
+        maxWidth: ttyMaxWidth
       },
       due: {
         minWidth: 12

--- a/lib/print-list.js
+++ b/lib/print-list.js
@@ -5,10 +5,10 @@ var moment = require('moment')
 var skipEmpty = true
 
 function printTasks (tasks) {
-  var ttyMaxWidth = 60;
+  var ttyMaxWidth = 60
 
   if (process.stdout.isTTY) {
-    ttyMaxWidth = process.stdout.columns;
+    ttyMaxWidth = process.stdout.columns
   }
 
   var options = {


### PR DESCRIPTION
I started using wunderline today and found that task title gets truncated when you have tasks title running for more than 60 characters or so, since most of my tasks are running past this limit I couldn't pretty much list my daily TODO tasks effectively. 

An example:
#### Current implementation

![60_char_limit](https://cloud.githubusercontent.com/assets/3181510/11930933/4b3e4024-a83c-11e5-9e63-2e1546499027.png)
#### What I am proposing

![dynamic_column_width_fix](https://cloud.githubusercontent.com/assets/3181510/11930954/7b9eb06e-a83c-11e5-9d56-fcd1e5f009b9.png)
