### PR TITLE
Include overdue items in the "today" smart list

### DIFF
--- a/wunderline-today.js
+++ b/wunderline-today.js
@@ -14,12 +14,13 @@ function main () {
   getLists(function (err, data) {
     if (err) process.exit(1)
 
-    var today = moment().format('YYYY-MM-DD')
+    var today = new Date()
 
     data.forEach(function (list) {
       list.tasks = list.tasks.filter(function (item) {
         if (!item.due_date) return false
-        return item.due_date === today
+        var due = new Date(item.due_date)
+        return due.getTime() <= today.getTime()
       })
 
       printList(list)


### PR DESCRIPTION
To keep parity between the CLI and the native GUI (at least for OSX), the Today smart list should include items that are Overdue as well as those explicitly due on that given day.

Fixes #89 
