### PR TITLE
Add --reminder flag to wunderline add

### DIFF
--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -207,24 +207,23 @@ function main() {
             callback(null, task);
           }
         },
-        function(task, cb) {
+        function(task, callback) {
           if (app.reminder) {
             api.post(
               {
                 url: "/reminders",
                 body: { task_id: task.id, date: reminderDatetime._d }
               },
-              function(err, res, body) {
-                if (err || body.error) {
-                  console.error(JSON.stringify(err || body.error, null, 2));
-                  process.exit(1);
+              function(error, response, body) {
+                if (error || body.error) {
+                  callback(error || body.error, null);
+                } else {
+                  callback(null, task);
                 }
-
-                cb(null, task);
               }
             );
           } else {
-            cb(null, task);
+            callback(null, task);
           }
         }
       ],

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -109,9 +109,9 @@ function main() {
   }
 
   if (app.reminder) {
-    if (moment(app.reminder).isValid()) {
+    if (moment(app.reminder, "YYYY-MM-DD HH:mm", true).isValid()) {
       reminderDatetime = moment(app.reminder);
-    } else if (moment(dueDate).isValid()) {
+    } else if (dueDate != null) {
       // set the dueDate as date for reminder, if no valid datetime given
       reminderDatetime = moment(dueDate);
     } else {

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -114,6 +114,9 @@ function main() {
     } else if (moment(dueDate).isValid()) {
       // set the dueDate as date for reminder, if no valid datetime given
       reminderDatetime = moment(dueDate);
+    } else {
+      console.error("Invalid reminder datetime!");
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
- if no valid datetime given (just time doesn't count as valid datetime), use dueDate

Do you think we should print an error and exit if no reminder-datetime given _and_ dueDate is invalid?
Additionally you should consider using `moment` to check for validity of `dueDate`.

Fix #72 
