### PR TITLE
Fix mixed-content-warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@
 title: Wunderline. Wunderlist for your command line!
 email: hello@wearenext.co.za
 description: Get stuff done with Wunderlist and your command line.
-baseurl: "http://wayneashleyberry.github.io/wunderline/"
-url: "http://wayneashleyberry.github.io/wunderline/"
+baseurl: "https://wayneashleyberry.github.io/wunderline/"
+url: "https://wayneashleyberry.github.io/wunderline/"
 github_username: wayneashleyberry
 google_analytics: UA-64418678-1
 twitter_username: nextct


### PR DESCRIPTION
by switching `baseurl` to https
