### PR TITLE
Refactor main to use async.waterfall properly

### DIFF
--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -60,7 +60,7 @@ function getListId(callback) {
     title: app.list.trim()
   };
 
-  api("/lists", function(error, res, body) {
+  api("/lists", function(error, response, body) {
     if (error) process.exit(1);
 
     var existing = body.filter(function(item) {
@@ -69,7 +69,7 @@ function getListId(callback) {
     if (existing.length > 0) {
       return callback(existing[0].id);
     }
-    api.post({ url: "/lists", body: list }, function(error, res, body) {
+    api.post({ url: "/lists", body: list }, function(error, response, body) {
       if (error) process.exit(1);
 
       callback(body.id);
@@ -129,7 +129,7 @@ function main() {
           });
         },
         function(task, callback) {
-          api.post({ url: "/tasks", body: task }, function(error, res, body) {
+          api.post({ url: "/tasks", body: task }, function(error, response, body) {
             if (error || body.error) {
               console.error(JSON.stringify(error || body.error, null, 2));
               process.exit(1);
@@ -143,7 +143,7 @@ function main() {
           if (app.note) {
             api.post(
               { url: "/notes", body: { task_id: task.id, content: app.note } },
-              function(error, res, body) {
+              function(error, response, body) {
                 if (error || body.error) {
                   console.error(JSON.stringify(error || body.error, null, 2));
                   process.exit(1);
@@ -172,7 +172,7 @@ function main() {
                     completed: false
                   }
                 },
-                function(error, res, body) {
+                function(error, response, body) {
                   if (error || body.error) {
                     console.error(JSON.stringify(error || body.error, null, 2));
                     process.exit(1);
@@ -186,12 +186,12 @@ function main() {
           }
         }
       ],
-      function(error, res) {
+      function(error, response) {
         if (error) {
           process.exit(1);
         }
         if (app.open) {
-          openTask(res);
+          openTask(response);
         }
         process.exit();
       }
@@ -237,7 +237,7 @@ function main() {
         async.each(
           tasks,
           function(task, finished) {
-            api.post({ url: "/tasks", body: task }, function(error, res, body) {
+            api.post({ url: "/tasks", body: task }, function(error, response, body) {
               if (error || body.error) {
                 console.error(JSON.stringify(error || body.error, null, 2));
                 process.exit(1);

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -155,7 +155,7 @@ function main() {
           }
         },
         function(task, callback) {
-          if (app.subtask) {
+          if (app.subtask.length > 0) {
             async.eachOfSeries(app.subtask, function(
               subtask,
               i,

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -49,10 +49,10 @@ function collect(value, memo) {
   return memo;
 }
 
-function getListId(cb) {
+function getListId(callback) {
   if (!app.list) {
     return getInbox(function(inbox) {
-      cb(inbox.id);
+      callback(inbox.id);
     });
   }
 
@@ -67,12 +67,12 @@ function getListId(cb) {
       return item.title.toLowerCase().trim() === list.title.toLowerCase();
     });
     if (existing.length > 0) {
-      return cb(existing[0].id);
+      return callback(existing[0].id);
     }
     api.post({ url: "/lists", body: list }, function(err, res, body) {
       if (err) process.exit(1);
 
-      cb(body.id);
+      callback(body.id);
     });
   });
 }
@@ -115,30 +115,30 @@ function main() {
 
     async.waterfall(
       [
-        function(cb) {
+        function(callback) {
           getListId(function(inboxId) {
-            cb(null, inboxId);
+            callback(null, inboxId);
           });
         },
-        function(inboxId, cb) {
-          cb(null, {
+        function(inboxId, callback) {
+          callback(null, {
             title: truncateTitle(title),
             list_id: inboxId,
             due_date: dueDate,
             starred: starred
           });
         },
-        function(task, cb) {
+        function(task, callback) {
           api.post({ url: "/tasks", body: task }, function(err, res, body) {
             if (err || body.error) {
               console.error(JSON.stringify(err || body.error, null, 2));
               process.exit(1);
             }
 
-            cb(null, body);
+            callback(null, body);
           });
         },
-        function(task, cb) {
+        function(task, callback) {
           app.note = app.note.replace(/\\n/g, "\n");
           if (app.note) {
             api.post(
@@ -149,14 +149,14 @@ function main() {
                   process.exit(1);
                 }
 
-                cb(null, task);
+                callback(null, task);
               }
             );
           } else {
-            cb(null, task);
+            callback(null, task);
           }
         },
-        function(task, cb) {
+        function(task, callback) {
           if (app.subtask) {
             async.eachOfSeries(app.subtask, function(
               subtask,
@@ -182,7 +182,7 @@ function main() {
               );
             });
           } else {
-            cb(null, task);
+            callback(null, task);
           }
         }
       ],
@@ -201,19 +201,19 @@ function main() {
   if (app.stdin === true) {
     async.waterfall(
       [
-        function(cb) {
+        function(callback) {
           stdin().then(data => {
             var sep = data.indexOf("\r\n") !== -1 ? "\r\n" : "\n";
             var lines = data.trim().split(sep);
-            cb(null, lines);
+            callback(null, lines);
           });
         },
-        function(lines, cb) {
+        function(lines, callback) {
           getListId(function(listId) {
-            cb(null, listId, lines);
+            callback(null, listId, lines);
           });
         },
-        function(listId, lines, cb) {
+        function(listId, lines, callback) {
           var tasks = lines
             .filter(function(line) {
               return line.trim().length > 0;
@@ -226,7 +226,7 @@ function main() {
                 starred: starred
               };
             });
-          cb(null, tasks);
+          callback(null, tasks);
         }
       ],
       function(err, tasks) {

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -160,31 +160,35 @@ function main() {
         },
         function(task, callback) {
           if (app.subtask.length > 0) {
-            async.eachSeries(app.subtask, function(subtask, subtask_callback) {
-              api.post(
-                {
-                  url: "/subtasks",
-                  body: {
-                    task_id: task.id,
-                    title: subtask,
-                    completed: false
+            async.eachSeries(
+              app.subtask,
+              function(subtask, subtask_callback) {
+                api.post(
+                  {
+                    url: "/subtasks",
+                    body: {
+                      task_id: task.id,
+                      title: subtask,
+                      completed: false
+                    }
+                  },
+                  function(error, response, body) {
+                    if (error || body.error) {
+                      subtask_callback(error || body.error);
+                    } else {
+                      subtask_callback();
+                    }
                   }
-                },
-                function(error, response, body) {
-                  if (error || body.error) {
-                    subtask_callback(error || body.error)
-                  } else {
-                    subtask_callback();
-                  }
+                );
+              },
+              function(error) {
+                if (error) {
+                  callback(error, null);
+                } else {
+                  callback(null, task);
                 }
-              );
-            }, function(error) {
-              if (error) {
-                callback(error, null)
-              } else {
-                callback(null, task)
               }
-            });
+            );
           } else {
             callback(null, task);
           }

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -129,9 +129,13 @@ function main() {
           });
         },
         function(task, callback) {
-          api.post({ url: "/tasks", body: task }, function(error, response, body) {
+          api.post({ url: "/tasks", body: task }, function(
+            error,
+            response,
+            body
+          ) {
             if (error || body.error) {
-              callback(error || body.error, null)
+              callback(error || body.error, null);
             } else {
               callback(null, body);
             }
@@ -144,14 +148,14 @@ function main() {
               { url: "/notes", body: { task_id: task.id, content: app.note } },
               function(error, response, body) {
                 if (error || body.error) {
-                  callback(error || body.error, null)
+                  callback(error || body.error, null);
                 } else {
-                  callback(null, task)
+                  callback(null, task);
                 }
               }
             );
           } else {
-            callback(null, task)
+            callback(null, task);
           }
         },
         function(task, callback) {
@@ -186,7 +190,7 @@ function main() {
       ],
       function(error, response) {
         if (error) {
-          console.error(JSON.stringify(error))
+          console.error(JSON.stringify(error));
           process.exit(1);
         }
         if (app.open) {
@@ -236,7 +240,11 @@ function main() {
         async.each(
           tasks,
           function(task, finished) {
-            api.post({ url: "/tasks", body: task }, function(error, response, body) {
+            api.post({ url: "/tasks", body: task }, function(
+              error,
+              response,
+              body
+            ) {
               if (error || body.error) {
                 console.error(JSON.stringify(error || body.error, null, 2));
                 process.exit(1);

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -131,11 +131,10 @@ function main() {
         function(task, callback) {
           api.post({ url: "/tasks", body: task }, function(error, response, body) {
             if (error || body.error) {
-              console.error(JSON.stringify(error || body.error, null, 2));
-              process.exit(1);
+              callback(error || body.error, null)
+            } else {
+              callback(null, body);
             }
-
-            callback(null, body);
           });
         },
         function(task, callback) {
@@ -145,15 +144,14 @@ function main() {
               { url: "/notes", body: { task_id: task.id, content: app.note } },
               function(error, response, body) {
                 if (error || body.error) {
-                  console.error(JSON.stringify(error || body.error, null, 2));
-                  process.exit(1);
+                  callback(error || body.error, null)
+                } else {
+                  callback(null, task)
                 }
-
-                callback(null, task);
               }
             );
           } else {
-            callback(null, task);
+            callback(null, task)
           }
         },
         function(task, callback) {
@@ -188,6 +186,7 @@ function main() {
       ],
       function(error, response) {
         if (error) {
+          console.error(JSON.stringify(error))
           process.exit(1);
         }
         if (app.open) {

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -172,10 +172,10 @@ function main() {
                 },
                 function(error, response, body) {
                   if (error || body.error) {
-                    console.error(JSON.stringify(error || body.error, null, 2));
-                    process.exit(1);
+                    subtask_callback(error || body.error)
+                  } else {
+                    subtask_callback();
                   }
-                  subtask_callback(null);
                 }
               );
             });

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -60,8 +60,8 @@ function getListId(callback) {
     title: app.list.trim()
   };
 
-  api("/lists", function(err, res, body) {
-    if (err) process.exit(1);
+  api("/lists", function(error, res, body) {
+    if (error) process.exit(1);
 
     var existing = body.filter(function(item) {
       return item.title.toLowerCase().trim() === list.title.toLowerCase();
@@ -69,8 +69,8 @@ function getListId(callback) {
     if (existing.length > 0) {
       return callback(existing[0].id);
     }
-    api.post({ url: "/lists", body: list }, function(err, res, body) {
-      if (err) process.exit(1);
+    api.post({ url: "/lists", body: list }, function(error, res, body) {
+      if (error) process.exit(1);
 
       callback(body.id);
     });
@@ -129,9 +129,9 @@ function main() {
           });
         },
         function(task, callback) {
-          api.post({ url: "/tasks", body: task }, function(err, res, body) {
-            if (err || body.error) {
-              console.error(JSON.stringify(err || body.error, null, 2));
+          api.post({ url: "/tasks", body: task }, function(error, res, body) {
+            if (error || body.error) {
+              console.error(JSON.stringify(error || body.error, null, 2));
               process.exit(1);
             }
 
@@ -143,9 +143,9 @@ function main() {
           if (app.note) {
             api.post(
               { url: "/notes", body: { task_id: task.id, content: app.note } },
-              function(err, res, body) {
-                if (err || body.error) {
-                  console.error(JSON.stringify(err || body.error, null, 2));
+              function(error, res, body) {
+                if (error || body.error) {
+                  console.error(JSON.stringify(error || body.error, null, 2));
                   process.exit(1);
                 }
 
@@ -172,9 +172,9 @@ function main() {
                     completed: false
                   }
                 },
-                function(err, res, body) {
-                  if (err || body.error) {
-                    console.error(JSON.stringify(err || body.error, null, 2));
+                function(error, res, body) {
+                  if (error || body.error) {
+                    console.error(JSON.stringify(error || body.error, null, 2));
                     process.exit(1);
                   }
                   subtask_callback(null);
@@ -186,8 +186,8 @@ function main() {
           }
         }
       ],
-      function(err, res) {
-        if (err) {
+      function(error, res) {
+        if (error) {
           process.exit(1);
         }
         if (app.open) {
@@ -229,17 +229,17 @@ function main() {
           callback(null, tasks);
         }
       ],
-      function(err, tasks) {
-        if (err) {
+      function(error, tasks) {
+        if (error) {
           process.exit(1);
         }
 
         async.each(
           tasks,
           function(task, finished) {
-            api.post({ url: "/tasks", body: task }, function(err, res, body) {
-              if (err || body.error) {
-                console.error(JSON.stringify(err || body.error, null, 2));
+            api.post({ url: "/tasks", body: task }, function(error, res, body) {
+              if (error || body.error) {
+                console.error(JSON.stringify(error || body.error, null, 2));
                 process.exit(1);
               }
               process.stderr.write(".");

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -178,6 +178,12 @@ function main() {
                   }
                 }
               );
+            }, function(error) {
+              if (error) {
+                callback(error, null)
+              } else {
+                callback(null, task)
+              }
             });
           } else {
             callback(null, task);

--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -160,11 +160,7 @@ function main() {
         },
         function(task, callback) {
           if (app.subtask.length > 0) {
-            async.eachOfSeries(app.subtask, function(
-              subtask,
-              i,
-              subtask_callback
-            ) {
+            async.eachSeries(app.subtask, function(subtask, subtask_callback) {
               api.post(
                 {
                   url: "/subtasks",


### PR DESCRIPTION
We didn't use `async.waterfall`s error handling capabilities at all and just implemented error handling for each sub-request separetely, this Pull Request will replace those occurences with a call to `callback` passing the error and handling it at one, central point.

While looking at `async`s documentation I realized my assumption in #111 about the order of `eachOf`-execution was wrong so I changed it to use it instead of `eachOfSeries` which gave us an unused index-argument. There was a call to `callback` missing at the end as well, so `async.waterfall`s final callback was never executed (therefore "disabling" `--open`-functionality).

Additionaly I renamed all short-forms of variable names to their long forms because I don't really see a value in making the code less readable just to save some space (or some typing if your editor doesn't support auto-completion), but I can take those commits out if you don't agree on that.

This should fix the blocking problems in #94 as well.