### PR TITLE
Add users command and --assignee flag to add

### DIFF
--- a/wunderline-add.js
+++ b/wunderline-add.js
@@ -37,6 +37,7 @@ app
   .option("--note [note]", "Attach a note to the new task")
   .option("--subtask [task]", "Add a subtask to the new task", collect, [])
   .option("--reminder [datetime]", "Add a reminder to the new task")
+  .option("--assignee [id]", "Assign this task to a user")
   .option("-o, --open", "Open Wunderlist on completion")
   .option("-s, --stdin", "Create tasks from stdin")
   .parse(process.argv);
@@ -82,6 +83,7 @@ function main() {
   var dueDate;
   var reminderDatetime;
   var starred = false;
+  var assignee;
 
   if (app.today) {
     dueDate = moment();
@@ -123,6 +125,10 @@ function main() {
     }
   }
 
+  if (app.assignee) {
+    assignee = parseInt(app.assignee);
+  }
+
   if (typeof app.stdin === "undefined") {
     var title = app.args.join(" ");
 
@@ -142,7 +148,8 @@ function main() {
             title: truncateTitle(title),
             list_id: inboxId,
             due_date: dueDate,
-            starred: starred
+            starred: starred,
+            assignee_id: assignee
           });
         },
         function(task, callback) {

--- a/wunderline-users.js
+++ b/wunderline-users.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+var app = require("commander");
+var api = require("./lib/api");
+var auth = require("./lib/auth");
+
+app
+  .description("Display users related to the current account")
+  .parse(process.argv);
+
+function main() {
+  api("/users", function(err, res, body) {
+    if (err || body.error) {
+      console.error(JSON.stringify(err || body.error, null, 2));
+      process.exit(1);
+    }
+    body.forEach(function(user) {
+      console.log("— " + user.name + ", " + user.email + " (" + user.id + ")");
+    });
+  });
+}
+
+auth(main);

--- a/wunderline.js
+++ b/wunderline.js
@@ -22,6 +22,7 @@ app
   .command("whoami", "Display effective user")
   .command("gc", "Delete completed tasks")
   .command("set-platform", "Set your preferred application platform")
-  .command("flush", "Flush the application cache");
+  .command("flush", "Flush the application cache")
+  .command("users", "Display users related to the current account");
 
 app.parse(process.argv);


### PR DESCRIPTION
This PR adds the features required to assign tasks to users.

The current workflow looks like this:
```
$ wunderline users
— abc, abc@example.com (1)
— asdf, asdf@example.com (2)
$ wunderline add -l SharedList --assignee 1 Task1
$ wunderline add -l SharedList --assignee 2 Task2
```

Fix #121 